### PR TITLE
Changed intval to int, removed break lines

### DIFF
--- a/SkypeStatus.php
+++ b/SkypeStatus.php
@@ -21,8 +21,7 @@ class SkypeStatus {
     protected $xmlObject;
 
     public function __construct($username) {
-        $xmlString = @file_get_contents("http://mystatus.skype.com/" . $username .
-            ".xml");
+        $xmlString = @file_get_contents("http://mystatus.skype.com/" . $username . ".xml");
         return ($xmlString) ? $this->xmlObject = new SimpleXMLElement($xmlString) : null;
     }
 
@@ -35,8 +34,7 @@ class SkypeStatus {
     }
 
     public function getStatusString() {
-        return ($this->checkObject()) ? $this->languageArray[intval($this->
-            getStatusCode())] : null;
+        return ($this->checkObject()) ? $this->languageArray[(int)$this->getStatusCode()] : null;
     }
 
 }


### PR DESCRIPTION
intval is a function so its a bit slower than (int).
intval would be useful if the status code here was a non-decimal base.
Check http://stackoverflow.com/questions/239136/fastest-way-to-convert-string-to-integer-in-php
It seems that co-ersion is a tiny bit faster than (int)
